### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of the school's GitHub Certifications program",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Closes #6

A GitHub Skills tevékenység hozzáadása az iskolai tevékenységek listájához.

### Változtatások
- Új `"GitHub Skills"` bejegyzés az `activities` szótárban (`src/app.py`)
- Leírás, menetrend (szerdánként 15:30–17:00) és max. 25 fős kapacitás beállítva

### Indoklás
Az igazgató az iskolagyűlésen bejelentette a GitHub partnerséget. A beiratkozás a hét végén lezárul, ezért ez sürgős javítás volt.